### PR TITLE
reroute google login to login page

### DIFF
--- a/app/controllers/auth/google_signup_controller.ts
+++ b/app/controllers/auth/google_signup_controller.ts
@@ -62,7 +62,7 @@ export default class GoogleSignupController {
       if (google.accessDenied() || google.stateMisMatch() || google.hasError()) {
         logger.info(logContext, 'Google auth failed')
         session.flash('error', 'Authentication failed. Please try again.')
-        return response.redirect().toRoute('login')
+        return response.redirect().toRoute('/login')
       }
 
       const googleUser = await google.user()


### PR DESCRIPTION
This pull request includes a small change to the `GoogleSignupController` in the `app/controllers/auth/google_signup_controller.ts` file. The change corrects the route redirection path for failed Google authentication attempts.

* [`app/controllers/auth/google_signup_controller.ts`](diffhunk://#diff-2a6dcf46e85c257c1bb82abd9be62b38e13c6de45ba73804b0b5426f45ebeb43L65-R65): Modified the redirection route from `'login'` to `'/login'` to ensure proper routing on authentication failure.