### PR TITLE
edit and delete paper

### DIFF
--- a/components.d.ts
+++ b/components.d.ts
@@ -7,10 +7,10 @@ export {}
 /* prettier-ignore */
 declare module 'vue' {
   export interface GlobalComponents {
-    AdminSearch: typeof import('./inertia/components/AdminSearch.vue')['default']
     AddMcqDialog: typeof import('./inertia/components/AddMcqDialog.vue')['default']
     AddQuestionDialog: typeof import('./inertia/components/AddQuestionDialog.vue')['default']
     AddSaqDialog: typeof import('./inertia/components/AddSaqDialog.vue')['default']
+    AdminSearch: typeof import('./inertia/components/AdminSearch.vue')['default']
     Alert: typeof import('./inertia/components/ui/alert/Alert.vue')['default']
     AlertDescription: typeof import('./inertia/components/ui/alert/AlertDescription.vue')['default']
     AlertTitle: typeof import('./inertia/components/ui/alert/AlertTitle.vue')['default']
@@ -29,6 +29,7 @@ declare module 'vue' {
     DialogTitle: typeof import('./inertia/components/ui/dialog/DialogTitle.vue')['default']
     DialogTrigger: typeof import('./inertia/components/ui/dialog/DialogTrigger.vue')['default']
     EditMcqDialog: typeof import('./inertia/components/EditMcqDialog.vue')['default']
+    EditPaperDialog: typeof import('./inertia/components/EditPaperDialog.vue')['default']
     EditSaqDialog: typeof import('./inertia/components/EditSaqDialog.vue')['default']
     FormControl: typeof import('./inertia/components/ui/form/FormControl.vue')['default']
     FormDescription: typeof import('./inertia/components/ui/form/FormDescription.vue')['default']
@@ -65,7 +66,6 @@ declare module 'vue' {
     ToastProvider: typeof import('./inertia/components/ui/toast/ToastProvider.vue')['default']
     ToastTitle: typeof import('./inertia/components/ui/toast/ToastTitle.vue')['default']
     ToastViewport: typeof import('./inertia/components/ui/toast/ToastViewport.vue')['default']
-    Toggle: typeof import('./inertia/components/ToggleUrl.vue')['default']
     ToggleUrl: typeof import('./inertia/components/ToggleUrl.vue')['default']
     UploadMcqsDialog: typeof import('./inertia/components/UploadMcqsDialog.vue')['default']
     UploadQuestionsDialog: typeof import('./inertia/components/UploadQuestionsDialog.vue')['default']

--- a/inertia/components/EditPaperDialog.vue
+++ b/inertia/components/EditPaperDialog.vue
@@ -1,0 +1,87 @@
+<script setup lang="ts">
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from '~/components/ui/dialog'
+import { useForm } from '@inertiajs/vue3'
+import type PastPaperDto from '#dtos/past_paper'
+import type ConceptDto from '#dtos/concept'
+import { ExamType, PaperType, PaperTypeLabels, ExamTypeLabels } from '#enums/exam_type'
+
+const props = defineProps<{
+  open: boolean
+  paper: PastPaperDto
+  concept: ConceptDto
+}>()
+
+const emit = defineEmits<{
+  'update:open': [value: boolean]
+}>()
+
+const form = useForm({
+  title: props.paper.title,
+  year: props.paper.year,
+  paperType: props.paper.paperType,
+  examType: props.paper.examType,
+})
+
+function handleSubmit() {
+  form.put(`/manage/papers/${props.concept.slug}/${props.paper.slug}`, {
+    preserveScroll: true,
+    onSuccess: () => {
+      emit('update:open', false)
+    },
+  })
+}
+</script>
+
+<template>
+  <Dialog :open="open" @update:open="$emit('update:open', $event)">
+    <DialogContent class="sm:max-w-[425px]">
+      <DialogHeader>
+        <DialogTitle>Edit Paper</DialogTitle>
+      </DialogHeader>
+
+      <form @submit.prevent="handleSubmit" class="space-y-6">
+        <div class="space-y-2">
+          <Label>Title</Label>
+          <Input v-model="form.title" :error="form.errors.title" />
+        </div>
+
+        <div class="space-y-2">
+          <Label>Year</Label>
+          <Input v-model="form.year" :error="form.errors.year" />
+        </div>
+
+        <div class="space-y-2">
+          <Label>Paper Type</Label>
+          <Select v-model="form.paperType">
+            <SelectTrigger :class="{ 'border-red-500': form.errors.paperType }">
+              <SelectValue placeholder="Select paper type" />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem v-for="type in Object.values(PaperType)" :key="type" :value="type">
+                {{ PaperTypeLabels[type] }}
+              </SelectItem>
+            </SelectContent>
+          </Select>
+        </div>
+
+        <div class="space-y-2">
+          <Label>Exam Type</Label>
+          <Select v-model="form.examType">
+            <SelectTrigger :class="{ 'border-red-500': form.errors.examType }">
+              <SelectValue placeholder="Select exam type" />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem v-for="type in Object.values(ExamType)" :key="type" :value="type">
+                {{ ExamTypeLabels[type] }}
+              </SelectItem>  
+            </SelectContent>
+          </Select>
+        </div>
+
+        <Button type="submit" :disabled="form.processing">
+          {{ form.processing ? 'Saving...' : 'Save Changes' }}
+        </Button>
+      </form>
+    </DialogContent>
+  </Dialog>
+</template>

--- a/inertia/layouts/AdminLayout.vue
+++ b/inertia/layouts/AdminLayout.vue
@@ -46,9 +46,6 @@ const menuItems = [
         <div class="flex-1 mx-auto max-w-2xl">
           <AdminSearch />
         </div>
-        <div class="flex items-center gap-4">
-          <Button variant="ghost" @click="$inertia.post('/logout')">Logout</Button>
-        </div>
         <Button
           variant="ghost"
           @click="$inertia.post('/logout')"

--- a/inertia/layouts/DashLayout.vue
+++ b/inertia/layouts/DashLayout.vue
@@ -54,19 +54,18 @@ onUnmounted(() => {
       <div class="w-full px-4 sm:px-6">
         <div class="flex h-16 items-center justify-between">
           <!-- Left section -->
-          <div class="flex items-center gap-4 w-[200px]">
-            <!-- Add fixed width -->
+          <div class="flex items-center gap-4 lg:w-16">
             <button class="lg:hidden" @click="isSidebarCollapsed = !isSidebarCollapsed">
               <MenuIcon class="h-6 w-6" />
             </button>
-            <Link href="/learn" class="hidden md:block">
+            <Link href="/learn" class="hidden sm:block">
               <img :src="logoPath" alt="Logo" class="h-14 w-auto" />
             </Link>
           </div>
 
           <!-- Center search -->
-          <div class="flex-1 mx-auto max-w-2xl">
-              <Search />
+          <div class="flex-1 mx-4">
+            <Search />
           </div>
 
           <div class="relative user-menu shrink-0">

--- a/inertia/pages/manage/papers/view.vue
+++ b/inertia/pages/manage/papers/view.vue
@@ -10,6 +10,7 @@ import AddSaqQuestionDialog from '~/components/AddSaqDialog.vue'
 import UploadMcqsDialog from '~/components/UploadMcqsDialog.vue'
 import EditMcqDialog from '~/components/EditMcqDialog.vue'
 import EditSaqDialog from '~/components/EditSaqDialog.vue'
+import EditPaperDialog from '~/components/EditPaperDialog.vue'
 import { toast } from 'vue-sonner'
 import { useForm } from '@inertiajs/vue3'
 
@@ -68,6 +69,22 @@ async function handleDeleteQuestion(question: QuestionDto) {
   )
 }
 
+function handleDeletePaper() {
+  if (!confirm('Are you sure you want to delete this paper?')) return
+
+  const form = useForm({})
+
+  form.delete(`/manage/papers/${props.concept.slug}/${props.paper.slug}`, {
+    onSuccess: () => {
+      toast.success('Paper deleted successfully')
+      window.location.href = `/manage/papers/${props.concept.slug}`
+    },
+    onError: () => {
+      toast.error('Failed to delete paper')
+    },
+  })
+}
+
 function handleEditQuestion(question: QuestionDto) {
   if (question.isMcq) {
     showEditMcqDialog.value = true
@@ -92,6 +109,7 @@ const showAddSaqDialog = ref(false)
 const showUploadDialog = ref(false)
 const showEditMcqDialog = ref(false)
 const showEditSaqDialog = ref(false)
+const showEditPaperDialog = ref(false)
 const selectedQuestion = ref<QuestionDto | null>(null)
 </script>
 
@@ -153,6 +171,12 @@ const selectedQuestion = ref<QuestionDto | null>(null)
           </Button>
           <Button class="w-full sm:w-auto" variant="outline" @click="showUploadDialog = true">
             <Upload class="h-4 w-4 mr-2" />Upload MCQs
+          </Button>
+          <Button variant="outline" class="w-full sm:w-auto" @click="showEditPaperDialog = true">
+            <Pencil class="h-4 w-4 mr-2" />Edit Paper
+          </Button>
+          <Button variant="destructive" class="w-full sm:w-auto" @click="handleDeletePaper">
+            <Trash2 class="h-4 w-4 mr-2" />Delete Paper
           </Button>
         </div>
       </div>
@@ -248,6 +272,7 @@ const selectedQuestion = ref<QuestionDto | null>(null)
     :concept="concept"
     :question="selectedQuestion"
   />
+  <EditPaperDialog v-model:open="showEditPaperDialog" :paper="paper" :concept="concept" />
   <!-- Progress Overlay -->
   <div
     v-if="parsingStatus.isProcessing"

--- a/start/routes.ts
+++ b/start/routes.ts
@@ -212,10 +212,7 @@ router
       ManagePapersController,
       'updateSaq',
     ])
-    // router.post('/:conceptSlug/:paperSlug/upload-questions', [
-    //   ManagePapersController,
-    //   'uploadQuestions',
-    // ])
+    router.put('/:conceptSlug/:paperSlug', [ManagePapersController, 'update'])
     router.delete('/:conceptSlug/:paperSlug/questions/:questionSlug', [
       ManagePapersController,
       'deleteQuestion',


### PR DESCRIPTION
This pull request introduces several new features and improvements related to managing past papers, including adding update functionality, enhancing the user interface, and refining routing. The most important changes are summarized below:

### Controller Enhancements:
* Added an `update` method to `ManagePastPapersController` to handle updating past papers, including validation and authorization checks.
* Modified the `destroy` method in `ManagePastPapersController` to use `params.paperSlug` instead of `params.slug` for consistency.
* Updated the redirect path in the `destroy` method to include `params.conceptSlug` for better navigation after deletion.

### User Interface Improvements:
* Added `EditPaperDialog` component to allow users to edit past papers within a dialog interface.
* Enhanced the `view.vue` page to include buttons for editing and deleting papers, and integrated the `EditPaperDialog` component. [[1]](diffhunk://#diff-b1e0bcf8ef23a29e97f2df95d78b65d18e45a0f796038fc97fc6a89a5c2d45abR72-R87) [[2]](diffhunk://#diff-b1e0bcf8ef23a29e97f2df95d78b65d18e45a0f796038fc97fc6a89a5c2d45abR175-R180) [[3]](diffhunk://#diff-b1e0bcf8ef23a29e97f2df95d78b65d18e45a0f796038fc97fc6a89a5c2d45abR275)

### Routing Adjustments:
* Added a new PUT route for updating papers in `start/routes.ts` to map to the `update` method in `ManagePastPapersController`.

These changes collectively improve the functionality and user experience for managing past papers in the application.