### PR TITLE
add custom redirect to session storage in login, register and email v…

### DIFF
--- a/app/constants/session.ts
+++ b/app/constants/session.ts
@@ -1,0 +1,3 @@
+export const SESSION_KEYS = {
+  RETURN_TO: 'return_to',
+} as const

--- a/app/controllers/auth/email_verification_controller.ts
+++ b/app/controllers/auth/email_verification_controller.ts
@@ -83,7 +83,12 @@ export default class VerificationController {
       })
 
       session.flash('success', 'Email verified successfully!')
-      return response.redirect().toPath('/learn')
+
+      // Get stored return URL from post-verify key
+      const returnTo = session.pull('post_verify_return', '/learn')
+      await session.regenerate()
+
+      return response.redirect().toPath(returnTo)
     } catch (error) {
       logger.error('Email verification failed', {
         error,

--- a/app/controllers/auth/login_controller.ts
+++ b/app/controllers/auth/login_controller.ts
@@ -1,7 +1,9 @@
 import WebLogin from '#actions/auth/http/web_login'
+import { SESSION_KEYS } from '#constants/session'
 import { loginValidator } from '#validators/auth'
 import { inject } from '@adonisjs/core'
 import type { HttpContext } from '@adonisjs/core/http'
+// import { returnToKey } from '#middleware/auth_middleware'
 
 export default class LoginController {
   @inject()
@@ -15,30 +17,80 @@ export default class LoginController {
   async store({ request, response, session, logger }: HttpContext, webLogin: WebLogin) {
     const requestId = crypto.randomUUID()
     try {
-      logger.info({ requestId, action: 'login.validate' }, 'Validating login credentials')
       const data = await request.validateUsing(loginValidator)
+      await webLogin.handle({ data })
+
       logger.info(
-        { requestId, action: 'login.validate.success', email: data.email },
-        'Login validation passed'
+        {
+          requestId,
+          action: 'login.session',
+          sessionData: session.all(),
+        },
+        'Session state before redirect'
       )
 
-      logger.info({ requestId, action: 'login.attempt', email: data.email }, 'Attempting login')
-      await webLogin.handle({ data })
-      logger.info({ requestId, action: 'login.success', email: data.email }, 'Login successful')
+      const returnTo = session.pull(SESSION_KEYS.RETURN_TO, '/learn')
 
+      logger.info(
+        {
+          requestId,
+          action: 'login.redirect',
+          returnTo,
+          email: data.email,
+        },
+        'Processing login redirect'
+      )
+
+      await session.regenerate()
       session.flash('success', 'Welcome back to Juvenotes')
-      return response.redirect().toPath('/learn')
+
+      return response.redirect().toPath(returnTo)
     } catch (error) {
       logger.error(
         {
           requestId,
           action: 'login.error',
           err: error,
-          email: request.input('email'),
         },
         'Login failed'
       )
       throw error
     }
   }
+
+  // @inject()
+  // async store({ request, response, session, logger }: HttpContext, webLogin: WebLogin) {
+  //   const requestId = crypto.randomUUID()
+  //   try {
+  //     logger.info({ requestId, action: 'login.validate' }, 'Validating login credentials')
+  //     const data = await request.validateUsing(loginValidator)
+  //     logger.info(
+  //       { requestId, action: 'login.validate.success', email: data.email },
+  //       'Login validation passed'
+  //     )
+
+  //     logger.info({ requestId, action: 'login.attempt', email: data.email }, 'Attempting login')
+  //     await webLogin.handle({ data })
+  //     logger.info({ requestId, action: 'login.success', email: data.email }, 'Login successful')
+
+  //     // Get stored URL and fall back to /learn
+  //     const returnTo = session.pull(SESSION_KEYS.RETURN_TO)
+  //     console.log('Retrieved return URL:', returnTo)
+  //     session.regenerate()
+
+  //     session.flash('success', 'Welcome back to Juvenotes')
+  //     return response.redirect().toPath(returnTo || '/learn')
+  //   } catch (error) {
+  //     logger.error(
+  //       {
+  //         requestId,
+  //         action: 'login.error',
+  //         err: error,
+  //         email: request.input('email'),
+  //       },
+  //       'Login failed'
+  //     )
+  //     throw error
+  //   }
+  // }
 }


### PR DESCRIPTION
This pull request introduces a new constant `SESSION_KEYS` and integrates it across various authentication controllers to manage return URLs after user actions like login, registration, and email verification. The changes ensure that users are redirected to the appropriate URL after these actions.

Key changes include:

### Session Management Enhancements:
* Added `SESSION_KEYS` constant to `app/constants/session.ts` for managing session keys.
* Updated `EmailVerificationController` to use the stored return URL from the session after email verification.

### Controller Updates:
* Modified `GoogleSignupController` to utilize `SESSION_KEYS.RETURN_TO` for redirecting users after login and registration. [[1]](diffhunk://#diff-2a6dcf46e85c257c1bb82abd9be62b38e13c6de45ba73804b0b5426f45ebeb43R23-R27) [[2]](diffhunk://#diff-2a6dcf46e85c257c1bb82abd9be62b38e13c6de45ba73804b0b5426f45ebeb43R46-R56)
* Updated `LoginController` to redirect users based on the `SESSION_KEYS.RETURN_TO` session value after login.
* Enhanced `RegisterController` to store the return URL in the session through the verification process.

### Middleware Changes:
* Modified `AuthMiddleware` to save the requested URL in the session using `SESSION_KEYS.RETURN_TO` if unauthorized access is encountered.