### PR TITLE
load question with relationships when updating SAQ

### DIFF
--- a/app/controllers/manage/past_papers/index_controller.ts
+++ b/app/controllers/manage/past_papers/index_controller.ts
@@ -370,7 +370,11 @@ export default class ManagePastPapersController {
   }
 
   async updateSaq({ params, request, response, auth, session, logger }: HttpContext) {
-    const question = await Question.findByOrFail('slug', params.questionSlug)
+    const question = await Question.query()
+      .where('slug', params.questionSlug)
+      .preload('pastPaper')
+      .firstOrFail()
+
     if (!question.isSaq) {
       return response.badRequest('Question is not SAQ type')
     }


### PR DESCRIPTION
This pull request includes a significant update to the `ManagePastPapersController` class in the `app/controllers/manage/past_papers/index_controller.ts` file. The most important change involves modifying the way a `Question` is fetched to include related `pastPaper` data.

Fetching `Question` with related data:

* [`app/controllers/manage/past_papers/index_controller.ts`](diffhunk://#diff-8056cad4c955b24b763dc9ff4a349af919c6f334a6520b99baab9b3ebae4eb24L373-R377): Changed the method to fetch a `Question` by its slug to use a query that preloads the associated `pastPaper` data. This ensures that the `pastPaper` relationship is loaded along with the `Question` object.