### PR TITLE
reduce past paper load times

### DIFF
--- a/app/controllers/manage/past_papers/index_controller.ts
+++ b/app/controllers/manage/past_papers/index_controller.ts
@@ -81,12 +81,13 @@ export default class ManagePastPapersController {
           .select(['id', 'title', 'year', 'exam_type', 'paper_type', 'slug', 'study_level'])
           .whereIn('paper_type', [PaperType.MCQ, PaperType.SAQ, PaperType.MIXED])
           .orderBy('year', 'desc')
-          .preload('questions', (questionsQuery) => {
-            questionsQuery
-              .select(['id', 'type', 'question_text', 'difficulty_level', 'past_paper_id'])
-              .preload('choices')
-              .preload('parts')
-          })
+          .withCount('questions')
+        // .preload('questions', (questionsQuery) => {
+        //   questionsQuery
+        //     .select(['id', 'type', 'question_text', 'difficulty_level', 'past_paper_id'])
+        //     .preload('choices')
+        //     .preload('parts')
+        // })
       })
       .firstOrFail()
 

--- a/app/controllers/papers/index_controller.ts
+++ b/app/controllers/papers/index_controller.ts
@@ -53,12 +53,12 @@ export default class IndexController {
           .select(['id', 'title', 'year', 'exam_type', 'paper_type', 'slug', 'study_level'])
           .whereIn('paper_type', [PaperType.MCQ, PaperType.SAQ, PaperType.MIXED])
           .orderBy('year', 'desc')
-          .preload('questions', (questionsQuery) => {
-            questionsQuery
-              .select(['id', 'type', 'question_text', 'difficulty_level', 'past_paper_id'])
-              .preload('choices')
-              .preload('parts')
-          })
+        // .preload('questions', (questionsQuery) => {
+        //   questionsQuery
+        //     .select(['id', 'type', 'question_text', 'difficulty_level', 'past_paper_id'])
+        //     .preload('choices')
+        //     .preload('parts')
+        // })
       })
       .firstOrFail()
 


### PR DESCRIPTION
This pull request includes changes to the `ManagePastPapersController` and `IndexController` classes to modify how questions are loaded and counted for past papers. The most important changes include replacing the preload of questions with a count of questions and commenting out the preload code.

Changes to question loading:

* [`app/controllers/manage/past_papers/index_controller.ts`](diffhunk://#diff-8056cad4c955b24b763dc9ff4a349af919c6f334a6520b99baab9b3ebae4eb24L84-R90): Replaced the preload of questions with a count of questions and commented out the preload code.
* [`app/controllers/papers/index_controller.ts`](diffhunk://#diff-1388b82922507dc954bfed0091b949ff2b0a068568dfb16e8a23ffc666ddadf3L56-R61): Commented out the preload of questions code.