### PR TITLE
saq fix

### DIFF
--- a/app/controllers/manage/past_papers/index_controller.ts
+++ b/app/controllers/manage/past_papers/index_controller.ts
@@ -81,13 +81,9 @@ export default class ManagePastPapersController {
           .select(['id', 'title', 'year', 'exam_type', 'paper_type', 'slug', 'study_level'])
           .whereIn('paper_type', [PaperType.MCQ, PaperType.SAQ, PaperType.MIXED])
           .orderBy('year', 'desc')
-          .withCount('questions')
-        // .preload('questions', (questionsQuery) => {
-        //   questionsQuery
-        //     .select(['id', 'type', 'question_text', 'difficulty_level', 'past_paper_id'])
-        //     .preload('choices')
-        //     .preload('parts')
-        // })
+          .preload('questions', (questionsQuery) => {
+            questionsQuery.select(['id', 'past_paper_id'])
+          })
       })
       .firstOrFail()
 

--- a/components.d.ts
+++ b/components.d.ts
@@ -75,6 +75,7 @@ declare module 'vue' {
     EditOsceDialog: typeof import('./inertia/components/dialogs/EditOsceDialog.vue')['default']
     EditPaperDialog: typeof import('./inertia/components/dialogs/EditPaperDialog.vue')['default']
     EditSaqDialog: typeof import('./inertia/components/dialogs/EditSaqDialog.vue')['default']
+    ExplanationEditor: typeof import('./inertia/components/ExplanationEditor.vue')['default']
     FormControl: typeof import('./inertia/components/ui/form/FormControl.vue')['default']
     FormDescription: typeof import('./inertia/components/ui/form/FormDescription.vue')['default']
     FormItem: typeof import('./inertia/components/ui/form/FormItem.vue')['default']
@@ -131,5 +132,6 @@ declare module 'vue' {
     TooltipProvider: typeof import('./inertia/components/ui/tooltip/TooltipProvider.vue')['default']
     TooltipTrigger: typeof import('./inertia/components/ui/tooltip/TooltipTrigger.vue')['default']
     UploadMcqsDialog: typeof import('./inertia/components/dialogs/UploadMcqsDialog.vue')['default']
+    ViewExplanation: typeof import('./inertia/components/ViewExplanation.vue')['default']
   }
 }

--- a/inertia/components/ExplanationEditor.vue
+++ b/inertia/components/ExplanationEditor.vue
@@ -1,0 +1,80 @@
+<script setup lang="ts">
+import { useEditor, EditorContent } from '@tiptap/vue-3'
+import StarterKit from '@tiptap/starter-kit'
+import { Markdown } from 'tiptap-markdown'
+import { List, ListOrdered, Bold, Italic } from 'lucide-vue-next'
+
+const props = defineProps<{
+  modelValue: string
+  placeholder?: string
+}>()
+
+const emit = defineEmits(['update:modelValue'])
+
+const editor = useEditor({
+  content: props.modelValue,
+  extensions: [
+    StarterKit,
+    Markdown.configure({
+      html: true,
+      tightLists: true,
+      bulletListMarker: '-',
+    }),
+  ],
+  editorProps: {
+    attributes: {
+      class: 'prose prose-sm max-w-none min-h-[100px] focus:outline-none',
+    },
+  },
+  onUpdate: ({ editor }) => {
+    emit('update:modelValue', editor.storage.markdown.getMarkdown())
+  },
+})
+
+const toolbar = [
+  {
+    icon: Bold,
+    title: 'Bold',
+    action: () => editor.value?.chain().focus().toggleBold().run(),
+  },
+  {
+    icon: Italic,
+    title: 'Italic',
+    action: () => editor.value?.chain().focus().toggleItalic().run(),
+  },
+  {
+    icon: List,
+    title: 'Bullet List',
+    action: () => editor.value?.chain().focus().toggleBulletList().run(),
+  },
+  {
+    icon: ListOrdered,
+    title: 'Numbered List',
+    action: () => editor.value?.chain().focus().toggleOrderedList().run(),
+  },
+]
+</script>
+
+<template>
+  <div class="border rounded-lg">
+    <!-- Toolbar -->
+    <div class="flex items-center gap-1 p-1 border-b bg-muted/50">
+      <button
+        v-for="item in toolbar"
+        :key="item.title"
+        type="button"
+        @click="item.action"
+        class="p-1.5 rounded-lg hover:bg-accent transition-colors"
+        :title="item.title"
+      >
+        <component :is="item.icon" class="h-4 w-4" />
+      </button>
+    </div>
+
+    <!-- Editor Content -->
+    <EditorContent 
+      :editor="editor" 
+      class="p-3"
+    />
+  </div>
+</template>

--- a/inertia/components/ViewExplanation.vue
+++ b/inertia/components/ViewExplanation.vue
@@ -1,0 +1,50 @@
+<script setup lang="ts">
+import { unified } from 'unified'
+import remarkParse from 'remark-parse'
+import remarkGfm from 'remark-gfm'
+import remarkRehype from 'remark-rehype'
+import rehypeStringify from 'rehype-stringify'
+import { ref, watchEffect } from 'vue'
+
+const props = defineProps<{
+  content: string
+}>()
+
+const html = ref('')
+
+watchEffect(async () => {
+  const result = await unified()
+    .use(remarkParse)
+    .use(remarkGfm)
+    .use(remarkRehype)
+    .use(rehypeStringify)
+    .process(props.content)
+
+  html.value = String(result)
+})
+</script>
+
+<template>
+  <div 
+    class="markdown-content prose prose-sm max-w-none"
+    v-html="html"
+  />
+</template>
+
+<style scoped>
+.markdown-content {
+  :deep(ul) {
+    list-style-type: disc;
+    margin-left: 1.5rem;
+  }
+
+  :deep(ol) {
+    list-style-type: decimal;
+    margin-left: 1.5rem;
+  }
+
+  :deep(li) {
+    margin-bottom: 0.25rem;
+  }
+}
+</style>

--- a/inertia/components/dialogs/AddSaqDialog.vue
+++ b/inertia/components/dialogs/AddSaqDialog.vue
@@ -98,11 +98,16 @@ const handleSubmit = () => {
               </div>
 
               <div class="space-y-2">
-                <Textarea
+                <!-- <Textarea
                   v-model="part.expectedAnswer"
                   :placeholder="'Expected answer can include lists:\n- Point 1\n- Point 2\n- Point 3'"
                   rows="4"
                   class="resize-y min-h-[100px]"
+                /> -->
+                <Label>Expected Answer</Label>
+                <ExplanationEditor
+                  v-model="part.expectedAnswer"
+                  placeholder="Enter expected answer"
                 />
               </div>
 

--- a/inertia/pages/manage/papers/view.vue
+++ b/inertia/pages/manage/papers/view.vue
@@ -229,7 +229,14 @@ const selectedQuestion = ref<QuestionDto | null>(null)
                 class="relative pl-4 border-l-2 border-primary/20"
               >
                 <p class="font-medium">{{ part.partText }}</p>
-                <p class="text-muted-foreground mt-1">{{ part.expectedAnswer }}</p>
+                <div
+                  class="mt-4 p-6 bg-[#CDE5ED] shadow-md rounded-lg border border-[#A8D3E7]"
+                >
+                  <p class="text-base text-muted-foreground text-[#1F2937] font-medium">
+                    <strong>Explanation:</strong>
+                    <ViewExplanation :content="part.expectedAnswer" />
+                  </p>
+                </div>
                 <p class="text-xs text-primary mt-2">{{ part.marks }} marks</p>
               </div>
             </div>

--- a/inertia/pages/papers/view.vue
+++ b/inertia/pages/papers/view.vue
@@ -175,12 +175,21 @@ const getLastEditDate = computed(() => {
               </button>
 
               <!-- Explanation Section for Each Part -->
-              <div
+              <!-- <div
                 v-if="showAnswer[part.id]"
                 class="mt-4 p-6 bg-[#CDE5ED] shadow-md rounded-lg border border-[#A8D3E7]"
               >
                 <p class="text-base text-muted-foreground text-[#1F2937] font-medium">
                   <strong>Explanation:</strong> {{ part.expectedAnswer }}
+                </p>
+              </div> -->
+              <div
+                v-if="showAnswer[part.id]"
+                class="mt-4 p-6 bg-[#CDE5ED] shadow-md rounded-lg border border-[#A8D3E7]"
+              >
+                <p class="text-base text-muted-foreground text-[#1F2937] font-medium">
+                  <strong>Explanation:</strong>
+                  <ViewExplanation :content="part.expectedAnswer" />
                 </p>
               </div>
             </div>
@@ -190,3 +199,27 @@ const getLastEditDate = computed(() => {
     </div>
   </div>
 </template>
+<style scoped>
+.explanation-content {
+  :deep(ol) {
+    list-style-type: decimal;
+    margin-left: 1.5rem;
+    margin-top: 0.5rem;
+  }
+
+  :deep(ul) {
+    list-style-type: disc;
+    margin-left: 1.5rem;
+    margin-top: 0.5rem;
+  }
+
+  :deep(li) {
+    margin-bottom: 0.25rem;
+  }
+
+  :deep(hr) {
+    margin: 1rem 0;
+    border-top: 1px dashed #a8d3e7;
+  }
+}
+</style>


### PR DESCRIPTION
This pull request includes significant updates to the management and display of explanations in the past papers application. The changes primarily focus on integrating a new markdown editor and enhancing the display of explanations.

### Markdown Editor Integration:
* Added a new `ExplanationEditor` component using `@tiptap/vue-3` with markdown support and a toolbar for text formatting. (`inertia/components/ExplanationEditor.vue`)
* Replaced the `Textarea` component with the new `ExplanationEditor` in the `AddSaqDialog` component. (`inertia/components/dialogs/AddSaqDialog.vue`)

### Explanation Display Enhancements:
* Introduced a `ViewExplanation` component to render markdown content as HTML using `unified` and related plugins. (`inertia/components/ViewExplanation.vue`)
* Updated the `view.vue` page to use the `ViewExplanation` component for displaying explanations. (`inertia/pages/manage/papers/view.vue`) [[1]](diffhunk://#diff-b1e0bcf8ef23a29e97f2df95d78b65d18e45a0f796038fc97fc6a89a5c2d45abL232-R239) [[2]](diffhunk://#diff-6bc8ea4d83c9e3ae4e5bb1053d0a041b53af67a338a3c94d6ff54a31408578c8L178-R193) [[3]](diffhunk://#diff-6bc8ea4d83c9e3ae4e5bb1053d0a041b53af67a338a3c94d6ff54a31408578c8R202-R225)

### Past Papers Query Optimization:
* Modified the `ManagePastPapersController` to preload only necessary fields for questions, improving query performance. (`app/controllers/manage/past_papers/index_controller.ts`)