### PR TITLE
explanations with markdown

### DIFF
--- a/inertia/components/ExplanationEditor.vue
+++ b/inertia/components/ExplanationEditor.vue
@@ -1,8 +1,9 @@
 <script setup lang="ts">
 import { useEditor, EditorContent } from '@tiptap/vue-3'
 import StarterKit from '@tiptap/starter-kit'
+import { Link } from '@tiptap/extension-link'
 import { Markdown } from 'tiptap-markdown'
-import { List, ListOrdered, Bold, Italic } from 'lucide-vue-next'
+import { List, ListOrdered, Bold, Italic, Link as LinkIcon } from 'lucide-vue-next'
 
 const props = defineProps<{
   modelValue: string
@@ -15,6 +16,13 @@ const editor = useEditor({
   content: props.modelValue,
   extensions: [
     StarterKit,
+    Link.configure({
+      openOnClick: true,
+      HTMLAttributes: {
+        target: '_blank',
+        rel: 'noopener noreferrer',
+      },
+    }),
     Markdown.configure({
       html: true,
       tightLists: true,
@@ -30,6 +38,17 @@ const editor = useEditor({
     emit('update:modelValue', editor.storage.markdown.getMarkdown())
   },
 })
+
+const addLink = () => {
+  const url = prompt('Enter URL:')
+  if (url) {
+    editor.value
+      ?.chain()
+      .focus()
+      .setLink({ href: url, target: '_blank', rel: 'noopener noreferrer' })
+      .run()
+  }
+}
 
 const toolbar = [
   {
@@ -52,6 +71,11 @@ const toolbar = [
     title: 'Numbered List',
     action: () => editor.value?.chain().focus().toggleOrderedList().run(),
   },
+  {
+    icon: LinkIcon,
+    title: 'Add Link',
+    action: addLink,
+  },
 ]
 </script>
 
@@ -72,9 +96,6 @@ const toolbar = [
     </div>
 
     <!-- Editor Content -->
-    <EditorContent 
-      :editor="editor" 
-      class="p-3"
-    />
+    <EditorContent :editor="editor" class="p-3" />
   </div>
 </template>

--- a/inertia/components/MdxContent.vue
+++ b/inertia/components/MdxContent.vue
@@ -17,9 +17,9 @@ const html = ref('')
 watchEffect(async () => {
   const result = await unified()
     .use(remarkParse)
+    .use(remarkGfm)
     .use(remarkRehype, { allowDangerousHtml: true })
     .use(rehypeRaw)
-    .use(remarkGfm) 
     .use(rehypeHighlight)
     .use(rehypeStringify)
     .process(props.content)
@@ -28,10 +28,7 @@ watchEffect(async () => {
 })
 </script>
 <template>
-  <div
-    class="prose dark:prose-invert max-w-none notion-like"
-    v-html="html"
-  />
+  <div class="prose dark:prose-invert max-w-none notion-like" v-html="html" />
 </template>
 
 <style>
@@ -126,15 +123,16 @@ watchEffect(async () => {
   }
 
   /* Links */
-  & a {
+  :deep(a:not([class])) {
     color: hsl(var(--primary));
+    text-decoration: underline;
+    text-decoration-thickness: 0.1em;
+    text-underline-offset: 0.2em;
+    transition: color 0.2s ease-in-out;
     font-weight: 500;
-    position: relative;
-    text-decoration: none;
-    transition: var(--notion-transition);
 
     &:hover {
-      text-decoration: underline;
+      color: hsl(var(--primary) / 0.8);
     }
   }
 

--- a/inertia/components/ViewExplanation.vue
+++ b/inertia/components/ViewExplanation.vue
@@ -16,7 +16,7 @@ watchEffect(async () => {
   const result = await unified()
     .use(remarkParse)
     .use(remarkGfm)
-    .use(remarkRehype)
+    .use(remarkRehype, { allowDangerousHtml: true })
     .use(rehypeStringify)
     .process(props.content)
 
@@ -45,6 +45,17 @@ watchEffect(async () => {
 
   :deep(li) {
     margin-bottom: 0.25rem;
+  }
+
+  :deep(a) {
+    color: hsl(var(--primary));
+    text-decoration: underline;
+    text-underline-offset: 0.2em;
+    transition: color 0.2s ease-in-out;
+
+    &:hover {
+      color: hsl(var(--primary) / 0.8);
+    }
   }
 }
 </style>

--- a/inertia/components/dialogs/AddMcqDialog.vue
+++ b/inertia/components/dialogs/AddMcqDialog.vue
@@ -129,7 +129,12 @@ const handleSubmit = () => {
               </div>
 
               <div class="space-y-2">
-                <Input v-model="choice.explanation" placeholder="Explanation (optional)" />
+                <!-- <Input v-model="choice.explanation" placeholder="Explanation (optional)" /> -->
+                <Label>Expected Answer</Label>
+                <ExplanationEditor
+                  v-model="choice.explanation"
+                  placeholder="Explanation (optional)"
+                />
               </div>
             </div>
           </div>

--- a/inertia/components/dialogs/EditMcqDialog.vue
+++ b/inertia/components/dialogs/EditMcqDialog.vue
@@ -134,7 +134,12 @@ const handleSubmit = () => {
               </div>
 
               <div class="space-y-2">
-                <Input v-model="choice.explanation" placeholder="Explanation (optional)" />
+                <!-- <Input v-model="choice.explanation" placeholder="Explanation (optional)" /> -->
+                <Label>Expected Answer</Label>
+                <ExplanationEditor
+                  v-model="choice.explanation"
+                  placeholder="Explanation (optional)"
+                />
               </div>
             </div>
           </div>

--- a/inertia/pages/manage/osce/view.vue
+++ b/inertia/pages/manage/osce/view.vue
@@ -187,7 +187,7 @@ const breadcrumbItems = computed(() => [
                 <div class="mt-3 bg-muted/50 rounded-lg p-3">
                   <p class="text-sm font-medium text-muted-foreground">Expected Answer:</p>
                   <div class="mt-2 text-sm sm:text-base whitespace-pre-wrap">
-                    {{ part.expectedAnswer }}
+                    <ViewExplanation :content="part.expectedAnswer" />
                   </div>
                 </div>
 

--- a/inertia/pages/manage/papers/view.vue
+++ b/inertia/pages/manage/papers/view.vue
@@ -215,7 +215,7 @@ const selectedQuestion = ref<QuestionDto | null>(null)
                     v-if="choice.isCorrect && choice.explanation"
                     class="text-sm text-muted-foreground mt-1"
                   >
-                    <span class="font-medium">Explanation:</span> {{ choice.explanation }}
+                    <span class="font-medium">Explanation:</span> <ViewExplanation :content="choice.explanation" />
                   </p>
                 </div>
               </div>

--- a/inertia/pages/osce/view.vue
+++ b/inertia/pages/osce/view.vue
@@ -148,7 +148,7 @@ const toggleAnswer = (questionIndex: number, partIndex: number) => {
                 >
                   <p class="text-sm font-semibold text-muted-foreground">Expected Answer:</p>
                   <div class="mt-2 text-md text-gray-800 leading-relaxed whitespace-pre-wrap">
-                    {{ part.expectedAnswer }}
+                    <ViewExplanation :content="part.expectedAnswer" />
                   </div>
                 </div>
 

--- a/inertia/pages/papers/view.vue
+++ b/inertia/pages/papers/view.vue
@@ -149,7 +149,7 @@ const getLastEditDate = computed(() => {
                 <strong>Correct Answer:</strong> {{ getCorrectAnswer(question)?.choiceText }}
               </p>
               <p class="mt-2 text-base text-muted-foreground text-[#1F2937] font-medium">
-                <strong>Explanation:</strong> {{ getCorrectAnswer(question)?.explanation }}
+                <ViewExplanation :content="getCorrectAnswer(question)?.explanation || ''" />
               </p>
             </div>
           </div>

--- a/resources/views/inertia_layout.edge
+++ b/resources/views/inertia_layout.edge
@@ -48,7 +48,7 @@
     rel="stylesheet"
   />
 
-  <style>
+  {{--  <style>
     :root {
       --sand-1: #fdfdfc;
       --sand-2: #f9f9f8;
@@ -63,13 +63,13 @@
       --sand-11: #63635e;
       --sand-12: #21201c;
     }
-  </style>
+  </style>  --}}
 
   {{-- <script src="https://cdn.tailwindcss.com"> --}}
 
   {{--  </script>  --}}
 
-  <script>
+  {{--  <script>
     tailwind.config = {
       theme: {
         extend: {
@@ -98,7 +98,7 @@
         }
       }
     };
-  </script>
+  </script>  --}}
 
   @vite(['inertia/app/app.ts', `inertia/pages/${page.component}.vue`])
   @inertiaHead()


### PR DESCRIPTION
This pull request includes several changes to enhance the functionality and styling of the `ExplanationEditor` component and to improve the handling of explanations across various components. The most important changes include the addition of link functionality to the `ExplanationEditor`, updates to the handling of explanations in multiple components, and minor stylistic adjustments.

Enhancements to `ExplanationEditor`:

* Added `Link` extension to the editor and configured it to open links in a new tab with `noopener noreferrer` attributes. (`inertia/components/ExplanationEditor.vue`, [[1]](diffhunk://#diff-153556ea2f74495ddd4e0270f93ddb8dd938fe5c0446e8649d62fefdd74ec8e7R4-R6) [[2]](diffhunk://#diff-153556ea2f74495ddd4e0270f93ddb8dd938fe5c0446e8649d62fefdd74ec8e7R19-R25)
* Implemented `addLink` function to prompt users for a URL and insert it into the editor content. (`inertia/components/ExplanationEditor.vue`, [inertia/components/ExplanationEditor.vueR42-R52](diffhunk://#diff-153556ea2f74495ddd4e0270f93ddb8dd938fe5c0446e8649d62fefdd74ec8e7R42-R52))
* Added a toolbar button for adding links using the `LinkIcon`. (`inertia/components/ExplanationEditor.vue`, [inertia/components/ExplanationEditor.vueR74-R78](diffhunk://#diff-153556ea2f74495ddd4e0270f93ddb8dd938fe5c0446e8649d62fefdd74ec8e7R74-R78))

Updates to explanation handling:

* Replaced `Input` fields with `ExplanationEditor` for explanations in `AddMcqDialog` and `EditMcqDialog`. (`inertia/components/dialogs/AddMcqDialog.vue`, [[1]](diffhunk://#diff-22120285226faedc0a40083528a1aeb0ea21bf27311deeff114c8441c461cca0L132-R137); `inertia/components/dialogs/EditMcqDialog.vue`, [[2]](diffhunk://#diff-0857819f0358a6cfd64c9b4e8529cfb26227192ac66a78c0a8de68c8099d3ad6L137-R142)
* Updated various components to use `ViewExplanation` for rendering explanations, ensuring consistent handling of explanation content. (`inertia/pages/manage/osce/view.vue`, [[1]](diffhunk://#diff-c7afd9715fc7982b148f5c249b780c40f695d7d363fc66d09d56f444cdf3abf0L190-R190); `inertia/pages/manage/papers/view.vue`, [[2]](diffhunk://#diff-b1e0bcf8ef23a29e97f2df95d78b65d18e45a0f796038fc97fc6a89a5c2d45abL218-R218) [[3]](diffhunk://#diff-6bc8ea4d83c9e3ae4e5bb1053d0a041b53af67a338a3c94d6ff54a31408578c8L152-R152); `inertia/pages/osce/view.vue`, [[4]](diffhunk://#diff-b8ad39bd5694834ac33c471804d973bbdac45d3395d2c9ffc0e079dcefe49906L151-R151)

Stylistic adjustments:

* Modified link styles in `MdxContent` and `ViewExplanation` components to include underlining and hover effects. (`inertia/components/MdxContent.vue`, [[1]](diffhunk://#diff-64c117a5a524881f90e1c6afea885c83442ace475436bf30988d2d0525c5692bL129-R135); `inertia/components/ViewExplanation.vue`, [[2]](diffhunk://#diff-96954d75f7139b26d5c2abb9e7e7f00001615fde94f76795ee9de072e1e7b76aR49-R59)
* Cleaned up unnecessary style tags in `inertia_layout.edge`. (`resources/views/inertia_layout.edge`, [[1]](diffhunk://#diff-94941a68657af553dc823f51ec9b1afab3b518677f22ca5458c120464b3332ecL51-R51) [[2]](diffhunk://#diff-94941a68657af553dc823f51ec9b1afab3b518677f22ca5458c120464b3332ecL66-R72) [[3]](diffhunk://#diff-94941a68657af553dc823f51ec9b1afab3b518677f22ca5458c120464b3332ecL101-R101)
/