### PR TITLE
fix getlastedited date

### DIFF
--- a/inertia/pages/concepts/show.vue
+++ b/inertia/pages/concepts/show.vue
@@ -46,7 +46,7 @@ const breadcrumbItems = computed(() => {
 })
 
 const getLastEditDate = computed(() => {
-  const date = new Date(props.paper.metadata?.lastEditedBy?.timestamp ?? props.paper.createdAt)
+  const date = new Date(props.concept.metadata?.lastEditedBy?.timestamp ?? props.concept.createdAt)
 
   return new Intl.DateTimeFormat('en-GB', {
     year: 'numeric',
@@ -54,7 +54,6 @@ const getLastEditDate = computed(() => {
     day: 'numeric',
   }).format(date)
 })
-
 watchEffect(() => {
   children.value = props.children
   questions.value = props.questions


### PR DESCRIPTION
This pull request includes a change to the `inertia/pages/concepts/show.vue` file to fix an issue with the date computation.

* The `getLastEditDate` computed property was modified to use `props.concept` instead of `props.paper` for retrieving metadata and creation date. This ensures that the correct concept metadata is used for determining the last edit date.