### PR TITLE
soft checks for less than 5 mcq per question

### DIFF
--- a/app/controllers/manage/past_papers/manage_papers_controller.ts
+++ b/app/controllers/manage/past_papers/manage_papers_controller.ts
@@ -168,31 +168,6 @@ export default class ManagePastPapersController {
     })
   }
 
-  // async viewPaper({ params, inertia, logger, auth }: HttpContext) {
-  //   const context = {
-  //     controller: 'ManagePastPapersController',
-  //     action: 'viewPaper',
-  //     paperSlug: params.paperSlug,
-  //     userId: auth.user?.id,
-  //   }
-  //   logger.info({ ...context, message: 'fetching paper details' })
-
-  //   const paper = await PastPaper.query()
-  //     .where('slug', params.paperSlug)
-  //     .whereIn('paper_type', [PaperType.MCQ, PaperType.SAQ, PaperType.MIXED])
-  //     .preload('concept')
-  //     .preload('questions', (query) => {
-  //       query.orderBy('id', 'asc').preload('choices').preload('parts')
-  //     })
-  //     .firstOrFail()
-
-  //   return inertia.render('manage/papers/view', {
-  //     paper: new PastPaperDto(paper),
-  //     concept: new ConceptDto(paper.concept),
-  //     questions: paper.questions ? QuestionDto.fromArray(paper.questions) : [],
-  //   })
-  // }
-
   /**
    * Store a new paper
    */
@@ -661,35 +636,6 @@ export default class ManagePastPapersController {
       throw error
     }
   }
-
-  // async deleteQuestion({ params, response, auth, session, logger }: HttpContext) {
-  //   try {
-  //     // Load question with pastPaper relationship
-  //     const question = await Question.query()
-  //       .where('slug', params.questionSlug)
-  //       .preload('pastPaper')
-  //       .firstOrFail()
-
-  //     await db.transaction(async (trx) => {
-  //       // Update paper metadata
-  //       await question.pastPaper
-  //         .merge({
-  //           metadata: this.getMetadataUpdate(question.pastPaper.metadata, auth),
-  //         })
-  //         .useTransaction(trx)
-  //         .save()
-
-  //       // Delete the question
-  //       await question.useTransaction(trx).delete()
-  //     })
-
-  //     session.flash('success', 'Question deleted successfully')
-  //     return response.redirect().back()
-  //   } catch (error) {
-  //     logger.error('failed to delete question', { error })
-  //     throw error
-  //   }
-  // }
 
   /**
    * Delete a paper

--- a/inertia/components/dialogs/UploadPdfQuestionsDialog.vue
+++ b/inertia/components/dialogs/UploadPdfQuestionsDialog.vue
@@ -140,9 +140,10 @@ async function handleUpload() {
                 }
               }
             )
+            // Allow questions with 0 or 1 choice (flexible)
             return {
               questionText,
-              choices: mappedChoices,
+              choices: mappedChoices, // can be empty or single
               explanation: q.explanation || '',
               questionImagePath: q.questionImagePath || null,
             }

--- a/inertia/pages/manage/papers/view.vue
+++ b/inertia/pages/manage/papers/view.vue
@@ -146,7 +146,7 @@ const showAddMcqDialog = ref(false)
 const showAddSaqDialog = ref(false)
 const showUploadDialog = ref(false)
 const showUploadPdfDialog = ref(false)
-// const showUploadPdfSaqDialog = ref(false)
+const showUploadPdfSaqDialog = ref(false)
 const showEditMcqDialog = ref(false)
 const showEditSaqDialog = ref(false)
 const showEditPaperDialog = ref(false)
@@ -224,9 +224,9 @@ const selectedQuestion = ref<QuestionDto | null>(null)
               <DropdownMenuItem @click="showUploadPdfDialog = true">
                 <Upload class="mr-2 h-4 w-4" /> Upload PDF (AI)
               </DropdownMenuItem>
-              <!-- <DropdownMenuItem @click="showUploadPdfSaqDialog = true">
+              <DropdownMenuItem @click="showUploadPdfSaqDialog = true">
                 <Upload class="mr-2 h-4 w-4" /> Upload PDF (SAQ)
-              </DropdownMenuItem> -->
+              </DropdownMenuItem>
               <DropdownMenuSeparator />
               <DropdownMenuItem @click="showEditPaperDialog = true">
                 <Pencil class="mr-2 h-4 w-4" /> Edit Paper
@@ -438,5 +438,5 @@ const selectedQuestion = ref<QuestionDto | null>(null)
   />
   <EditPaperDialog v-model:open="showEditPaperDialog" :paper="paper" :concept="concept" />
   <UploadPdfQuestionsDialog v-model:open="showUploadPdfDialog" :paper="paper" :concept="concept" />
-  <!-- <UploadPdfSaqsDialog v-model:open="showUploadPdfSaqDialog" :paper="paper" :concept="concept" /> -->
+<UploadPdfSaqsDialog v-model:open="showUploadPdfSaqDialog" :paper="paper" :concept="concept" />
 </template>


### PR DESCRIPTION
This pull request includes multiple changes aimed at refactoring unused code, improving the MCQ parsing logic, and enabling previously commented-out functionality in the user interface. Below is a summary of the most important changes:

### Code Cleanup and Refactoring
* Removed the unused `viewPaper` method from `ManagePastPapersController`, which was responsible for fetching and rendering paper details.
* Removed the unused `deleteQuestion` method from `ManagePastPapersController`, which handled deleting a question and updating metadata.

### Improvements to MCQ Parsing Logic
* Adjusted the minimum line requirement for parsing MCQ blocks from 7 to 3 in `MCQParser`.
* Enhanced choice parsing in `MCQParser` to dynamically detect valid choice lines (e.g., `A.`, `B)`), skip blocks with fewer than 2 choices, and log warnings for invalid blocks.

### UI Enhancements
* Re-enabled the previously commented-out `showUploadPdfSaqDialog` functionality in `view.vue`, allowing users to upload PDF files for SAQs. [[1]](diffhunk://#diff-b1e0bcf8ef23a29e97f2df95d78b65d18e45a0f796038fc97fc6a89a5c2d45abL149-R149) [[2]](diffhunk://#diff-b1e0bcf8ef23a29e97f2df95d78b65d18e45a0f796038fc97fc6a89a5c2d45abL227-R229) [[3]](diffhunk://#diff-b1e0bcf8ef23a29e97f2df95d78b65d18e45a0f796038fc97fc6a89a5c2d45abL441-R441)

### Relaxed Validation for Uploaded Questions
* Updated `UploadPdfQuestionsDialog.vue` to allow questions with 0 or 1 choice, providing more flexibility for uploaded questions.