### PR TITLE
feat: add docs for event

### DIFF
--- a/docs/event.md
+++ b/docs/event.md
@@ -1,0 +1,52 @@
+# Event Feature Breakdown
+
+## 1. Event Entity
+- **Fields:**
+  - Title/Name
+  - Description/Details
+  - Date & Time
+  - Location (physical/virtual)
+  - Option links (meeting link, partner websites, etc.)
+  - Image (URL or upload)
+  - Organizer/Host (optional)
+
+## 2. Event Quiz Entity
+- **Fields:**
+  - Tied to an Event (event_id)
+  - Title/Name
+  - Description/Details
+  - List of MCQs (multiple per event)
+  - Each MCQ:
+    - Question text
+    - Choices (options)
+    - Correct answer
+    - Explanation (optional)
+
+## 3. Relationships
+- One Event can have multiple Event Quizzes.
+- Each Event Quiz contains multiple MCQs.
+
+## 4. UI/UX Considerations
+- Event listing page (with image, date, location, links)
+- Event details page (with quizzes section)
+- Quiz-taking interface (MCQ format)
+
+## 5. UI/UX Implementation Details
+
+### User-Facing Side
+- Add an "Event" card to `/learn` alongside other cards.
+- **Event Index Page:** Lists all events.
+- **Event Show Page:** Displays event details (short description, date, location, image, links) at the top, followed by associated quizzes.
+- **Quiz Interface:** Opening a quiz uses `quiz.vue` and matches the MCQ UI used elsewhere.
+
+### Admin Side
+- Accessible via `/manage/event`.
+- **Event Index Page:** Lists all events with admin controls.
+- **Event Show Page:** Shows event details and quizzes, with buttons to create, edit, and delete events/quizzes.
+- **Quiz Interface:** Same as user side, with admin controls.
+- **Upload Questions:** Reuse logic for uploading questions from file.
+- **Image Upload:** Reuse existing image upload logic for event images.
+- **Date/Time:** Use Luxon library for datetime handling.
+
+### Development Instructions
+- Study how the existing "papers" and "today" pages work, including their backend logic, to guide implementation and reuse patterns/components where possible.


### PR DESCRIPTION
This pull request introduces documentation for the new Event feature, detailing its entities, relationships, UI/UX considerations, and implementation instructions for both user-facing and admin interfaces.

### Event Feature Documentation:

#### Entity Definitions:
- **Event Entity:** Includes fields such as title, description, date/time, location, links, image, and organizer.
- **Event Quiz Entity:** Contains fields for event association, title, description, and multiple-choice questions (MCQs) with question text, choices, correct answers, and optional explanations.

#### Relationships:
- Defined relationships between events and quizzes: one event can have multiple quizzes, and each quiz contains multiple MCQs.

#### UI/UX Considerations:
- **User-Facing Side:** Includes event listing and details pages, as well as a quiz interface integrated into the event details page using `quiz.vue`.
- **Admin Side:** Provides admin controls for managing events and quizzes, including creating, editing, deleting, uploading questions, and handling images and datetime using existing logic and the Luxon library.

#### Development Instructions:
- Developers are advised to study existing pages like "papers" and "today" to reuse backend patterns and components effectively for implementation.